### PR TITLE
Remove state pollution in `assist._usedWafTaskKeys`

### DIFF
--- a/tests/test_waf_assist.py
+++ b/tests/test_waf_assist.py
@@ -419,3 +419,5 @@ def testUsedWafTaskKeys():
     assert 'features' in keys
     assist.registerUsedWafTaskKeys(['t1', 't2'])
     assert assist.getUsedWafTaskKeys() - set(['t1', 't2']) == keys
+    assist._usedWafTaskKeys.remove('t1')
+    assist._usedWafTaskKeys.remove('t2')


### PR DESCRIPTION
This PR aims to improve test reliability of test `testUsedWafTaskKeys` by removing state pollution in `assist._usedWafTaskKeys` by calling method `remove`

The test can fail in this way if redundancy in `assist._usedWafTaskKeys` is not removed:
```
>       assert assist.getUsedWafTaskKeys() - set(['t1', 't2']) == keys
E       AssertionError: assert {'export_defi...ll_path', ...} == {'export_defi...ll_path', ...}
E         Extra items in the right set:
E         't2'
E         't1'
E         Use -v to get the full diff
